### PR TITLE
[ch11999] - Fix build constraints so they work on older versions of Golang.

### DIFF
--- a/definition_32bit.go
+++ b/definition_32bit.go
@@ -1,4 +1,4 @@
-//go:build (386 || arm || mipsle || mips || wasm)
+// +build 386,arm,mipsle,mips,wasm
 
 package backoff
 

--- a/definition_64bit.go
+++ b/definition_64bit.go
@@ -1,4 +1,4 @@
-//go:build !(386 || arm || mipsle || mips || wasm)
+// +build !386 !arm !mipsle !mips !wasm
 
 package backoff
 


### PR DESCRIPTION
[ch11999]